### PR TITLE
Add tests using mocha+chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Activity Streams 2.0 JavaScript Reference Implementation",
   "author": {
-    "name":"James M Snell",
-    "email":"jasnell@us.ibm.com"
+    "name": "James M Snell",
+    "email": "jasnell@us.ibm.com"
   },
   "keywords": [
     "activitystreams"
@@ -23,12 +23,17 @@
     }
   ],
   "devDependencies": {
+    "chai": "^1.9.1",
     "grunt": "~0.4.2",
+    "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-nodeunit": "~0.3.2",
     "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-jsdoc": "^0.5.4"
+    "grunt-jsdoc": "^0.5.4",
+    "mocha": "^1.20.1"
   },
-  "main": "./dist/activitystreams.js"
+  "main": "./dist/activitystreams.js",
+  "scripts": {
+    "test": "NODE_PATH=dist mocha -u exports test"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,31 @@
+/* jshint node: true */
+'use strict';
+
+var asms = require('activitystreams');
+var assert = require('chai').assert;
+
+var activity;
+
+exports.Activity = {
+  beforeEach: function () {
+    activity = asms.Activity({
+      verb: 'post',
+      actor: {
+        displayName: 'Joe',
+        id: 'acct:joe@example.org'
+      },
+      object: {
+        objectType: 'note',
+        content: 'This is a short note'
+      },
+      updated: new Date()
+    });
+  },
+  '#toString()': {
+    'does not throw an exception': function () {
+      assert.doesNotThrow(function () {
+        activity.toString();
+      });
+    }
+  }
+};


### PR DESCRIPTION
Includes reduced test case for a bug mentioned here
https://github.com/OpenSocial/activitystreams.js/issues/3

I tried to dig in to fix it, but couldn't figure it out. :(

So the tests run with `npm test`, but they fail because of that issue. May be worth adopting some test infrastructure even with this test disabled for now. Then, for example, you could set up [travis](https://travis-ci.org/) for this repo for free.
